### PR TITLE
Add checkout master after fetching from repo

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -17,6 +17,7 @@ file GH_PAGES_REF => BUILD_DIR do
     sh "git init"
     sh "git remote add origin #{repo_url}"
     sh "git fetch origin"
+    sh "git checkout master"
 
     if `git branch -r` =~ /gh-pages/
       sh "git checkout gh-pages"


### PR DESCRIPTION
Without checking out a branch, I was consistently getting "fatal: You are on a branch yet to be born" messages from git.
