### PR TITLE
On build task, copy the CNAME file if it exists

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -2,6 +2,7 @@ require 'fileutils'
 
 PROJECT_ROOT = `git rev-parse --show-toplevel`.strip
 BUILD_DIR    = File.join(PROJECT_ROOT, "build")
+CNAME_FILE   = 'CNAME'
 GH_PAGES_REF = File.join(BUILD_DIR, ".git/refs/remotes/origin/gh-pages")
 
 directory BUILD_DIR
@@ -54,6 +55,7 @@ desc "Compile all files into the build directory"
 task :build do
   cd PROJECT_ROOT do
     sh "bundle exec middleman build --clean"
+    cp(CNAME_FILE, File.join(BUILD_DIR, CNAME_FILE)) if File.exist?(CNAME_FILE)
   end
 end
 


### PR DESCRIPTION
Hi,

When we use `middleman-gh-pages` and a specific CNAME, we need to copy manually the `CNAME` file from the `source` to the `build` directory.

So I suggest, at the end of the `build` task, to copy the file to the build folder if a `CNAME` file exists.

What do you think about that?

Before, we have used submodules directly but the process was a bit longer. Thanks for your gem, it's really helpful! 

Kevin
