### PR TITLE
Customizing Commit Messages

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -60,10 +60,11 @@ end
 desc "Build and publish to Github Pages"
 task :publish => [:not_dirty, :prepare_git_remote_in_build_dir, :sync, :build] do
   message = nil
+  suffix = ENV["COMMIT_MESSAGE_SUFFIX"]
 
   cd PROJECT_ROOT do
     head = `git log --pretty="%h" -n1`.strip
-    message = "Site updated to #{head}"
+    message = ["Site updated to #{head}", suffix].compact.join("\n\n")
   end
 
   cd BUILD_DIR do


### PR DESCRIPTION
I've been experimenting with different continuous integration/deployment services lately. Not all are smart enough to skip builds on the gh-pages branch (specifically, I'm talking about Codeship), but one way around this is to add a message like "--skip-ci" or "[skip ci]" to the commit message to avoid the build.

So, what I'd like to suggest is an ability to customize the commit message that gets pushed to the gh-pages branch. I'm happy to code this up, but I wanted to get some buy-in for this feature first. I'm also looking for some guidance of how you'd like this implemented, because there are several ways to potentially handle this.
1. Allow a message argument to add a suffix to the publish task's commit message (meh)
2. Allow for an env variable to specify a suffix for the commit message (easy)
3. Build in some form of configurable commit message template (probably unnecessarily complex)
4. Always add "[skip ci]" to commit messages (easy, but not exactly ideal and limiting)

Thoughts?
