### PR TITLE
Update gh-pages.rake

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -4,8 +4,8 @@ def remote_name
   ENV.fetch("REMOTE_NAME", "origin")
 end
 
-PROJECT_ROOT = `git rev-parse --show-toplevel`.strip
-BUILD_DIR    = File.join(PROJECT_ROOT, "build")
+PROJECT_ROOT ||= `git rev-parse --show-toplevel`.strip
+BUILD_DIR    ||= File.join(PROJECT_ROOT, "build")
 GH_PAGES_REF = File.join(BUILD_DIR, ".git/refs/remotes/#{remote_name}/gh-pages")
 
 directory BUILD_DIR


### PR DESCRIPTION
Allow configuration of Website root directory.

I'm using middleman-gh-pages to publish the website of a C library project and doesn't want to have any Ruby stuff on the toplevel, mixed in with the autotools stuff. This quick and dirty patch allow you to configure the PROJECT_ROOT from the Rakefile (which isn't ideal but has the advantage of having the smallest impact possible on your code).