### PR TITLE
fixes failed dirty check for non-english git

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -49,7 +49,7 @@ end
 task :not_dirty do
   puts "***#{ENV['ALLOW_DIRTY']}***"
   unless ENV['ALLOW_DIRTY']
-    fail "Directory not clean" if /nothing to commit/ !~ `git status`
+    fail "Directory not clean" unless `git status --porcelain`.empty?
   end
 end
 

--- a/lib/middleman-gh-pages/version.rb
+++ b/lib/middleman-gh-pages/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module GithubPages
-    VERSION = "0.0.4"
+    VERSION = "0.0.3"
   end
 end

--- a/lib/middleman-gh-pages/version.rb
+++ b/lib/middleman-gh-pages/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module GithubPages
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
Hi! For non-english locales `git status` command responds with text that doesn't inclulde `nothing to commit` string. As a result repo seems as dirty for your task. `git` manpage (`man git status`) points me to `--porcelain` option that gives output for scripts and if there are nothing to commit it gives an empty string.

Example of `git status` output for russian locale:

```
$ git status
В ветке master
Your branch is up-to-date with 'origin/master'.

нечего фиксировать, рабочая директория пуста
```

Regards!