### PR TITLE
Fix: the dirty verification is system language dependent

### DIFF
--- a/lib/middleman-gh-pages/tasks/gh-pages.rake
+++ b/lib/middleman-gh-pages/tasks/gh-pages.rake
@@ -49,7 +49,7 @@ end
 task :not_dirty do
   puts "***#{ENV['ALLOW_DIRTY']}***"
   unless ENV['ALLOW_DIRTY']
-    fail "Directory not clean" if /nothing to commit/ !~ `git status`
+    fail "Directory not clean" unless (`git status --porcelain`).empty?
   end
 end
 


### PR DESCRIPTION
My system runs on Brazilian Portuguese. So, git messages are not in English. This fix makes the dirty verification not language dependent.